### PR TITLE
vim and xxd large file support

### DIFF
--- a/vim/Makefile
+++ b/vim/Makefile
@@ -38,6 +38,7 @@ AUTOCONF_OPTS += \
 
 TARBALL =		$(VER).tar.bz2
 TARBALL_COMPRESS =	-j
+CPPFLAGS +=	-D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
 
 include ../Makefile.targ
 include ../Makefile.targ.autoconf


### PR DESCRIPTION
Mostly required for xxd to support large files (bigger than 2 GB).
Tested on the current trunk of SmartOS Live with 2014 - current
zones on the machine.
