### PR TITLE
Add a semi-valid path for ssl certificates.

### DIFF
--- a/curl/Makefile
+++ b/curl/Makefile
@@ -28,7 +28,7 @@ include ../Makefile.defs
 TARBALL =		$(VER).tar.bz2
 TARBALL_COMPRESS =	-j
 
-AUTOCONF_OPTS +=	--with-ssl=$(DESTDIR)/usr
+AUTOCONF_OPTS +=	--with-ssl=$(DESTDIR)/usr --with-ca-bundle=/opt/local/share/ncat/ca-bundle.crt
 
 PATCHES =	Patches/*
 


### PR DESCRIPTION
Curl as shipped cannot negotiate ssl because it is missing a ca bundle. Adding this flag to ./configure makes it use the bundle which is shipped with netcat (a part of the base install).