### PR TITLE
OS-8252 Patch illumos-extra openssl for two CVEs

### DIFF
--- a/openssl1x/Patches/0007-CVE-2020-1968.patch
+++ b/openssl1x/Patches/0007-CVE-2020-1968.patch
@@ -1,0 +1,662 @@
+From: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>
+Date: Sun, 18 Dec 2016 15:37:52 +0100
+Subject: [PATCH] Mark 3DES and RC4 ciphers as weak
+
+This disables RC4 and 3DES in our build
+
+Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>
+diff -wpruN '--exclude=*.orig' a~/ssl/s3_lib.c a/ssl/s3_lib.c
+--- a~/ssl/s3_lib.c	1970-01-01 00:00:00
++++ a/ssl/s3_lib.c	1970-01-01 00:00:00
+@@ -216,6 +216,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ #endif
+ 
+ /* Cipher 04 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_RSA_RC4_128_MD5,
+@@ -230,8 +231,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+ /* Cipher 05 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_RSA_RC4_128_SHA,
+@@ -246,7 +249,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
+-
++#endif
+ /* Cipher 06 */
+ #ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+@@ -320,6 +323,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ #endif
+ 
+ /* Cipher 0A */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_RSA_DES_192_CBC3_SHA,
+@@ -334,6 +338,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+ /* The DH ciphers */
+ /* Cipher 0B */
+@@ -373,6 +378,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ #endif
+ 
+ /* Cipher 0D */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_DH_DSS_DES_192_CBC3_SHA,
+@@ -387,6 +393,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+ /* Cipher 0E */
+ #ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+@@ -425,6 +432,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ #endif
+ 
+ /* Cipher 10 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_DH_RSA_DES_192_CBC3_SHA,
+@@ -439,6 +447,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+ /* The Ephemeral DH ciphers */
+ /* Cipher 11 */
+@@ -478,6 +487,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ #endif
+ 
+ /* Cipher 13 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_EDH_DSS_DES_192_CBC3_SHA,
+@@ -492,6 +502,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+ /* Cipher 14 */
+ #ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+@@ -530,6 +541,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ #endif
+ 
+ /* Cipher 16 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_EDH_RSA_DES_192_CBC3_SHA,
+@@ -544,6 +556,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+ /* Cipher 17 */
+ #ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+@@ -564,6 +577,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ #endif
+ 
+ /* Cipher 18 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_ADH_RC4_128_MD5,
+@@ -578,6 +592,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+ /* Cipher 19 */
+ #ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+@@ -616,6 +631,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ #endif
+ 
+ /* Cipher 1B */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_ADH_DES_192_CBC_SHA,
+@@ -630,6 +646,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+ /* Fortezza ciphersuite from SSL 3.0 spec */
+ #if 0
+@@ -703,6 +720,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ # endif
+ 
+ /* Cipher 1F */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_KRB5_DES_192_CBC3_SHA,
+@@ -717,8 +735,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+ /* Cipher 20 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_KRB5_RC4_128_SHA,
+@@ -733,6 +753,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+ /* Cipher 21 */
+     {
+@@ -769,6 +790,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ # endif
+ 
+ /* Cipher 23 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_KRB5_DES_192_CBC3_MD5,
+@@ -783,8 +805,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+ /* Cipher 24 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      SSL3_TXT_KRB5_RC4_128_MD5,
+@@ -799,6 +823,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+ /* Cipher 25 */
+     {
+@@ -942,6 +967,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      },
+ /* Cipher 30 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_AES_128_SHA,
+@@ -956,7 +982,9 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ /* Cipher 31 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_AES_128_SHA,
+@@ -971,6 +999,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ /* Cipher 32 */
+     {
+      1,
+@@ -1033,6 +1062,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      256,
+      },
+ /* Cipher 36 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_AES_256_SHA,
+@@ -1047,8 +1077,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      256,
+      256,
+      },
++#endif
+ 
+ /* Cipher 37 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_AES_256_SHA,
+@@ -1063,6 +1095,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      256,
+      256,
+      },
++#endif
+ 
+ /* Cipher 38 */
+     {
+@@ -1162,6 +1195,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      },
+ 
+     /* Cipher 3E */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_AES_128_SHA256,
+@@ -1176,8 +1210,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 3F */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_AES_128_SHA256,
+@@ -1192,6 +1228,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 40 */
+     {
+@@ -1229,6 +1266,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      },
+ 
+     /* Cipher 42 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_CAMELLIA_128_CBC_SHA,
+@@ -1243,8 +1281,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 43 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_CAMELLIA_128_CBC_SHA,
+@@ -1259,6 +1299,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 44 */
+     {
+@@ -1418,6 +1459,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ # endif
+ 
+     /* Cipher 66 */
++# ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DHE_DSS_WITH_RC4_128_SHA,
+@@ -1433,6 +1475,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      },
+ #endif
++#endif
+ 
+     /* TLS v1.2 ciphersuites */
+     /* Cipher 67 */
+@@ -1452,6 +1495,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      },
+ 
+     /* Cipher 68 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_AES_256_SHA256,
+@@ -1466,8 +1510,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      256,
+      256,
+      },
++#endif
+ 
+     /* Cipher 69 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_AES_256_SHA256,
+@@ -1482,6 +1528,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      256,
+      256,
+      },
++#endif
+ 
+     /* Cipher 6A */
+     {
+@@ -1621,6 +1668,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      256,
+      },
+     /* Cipher 85 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_CAMELLIA_256_CBC_SHA,
+@@ -1635,8 +1683,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      256,
+      256,
+      },
++#endif
+ 
+     /* Cipher 86 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_CAMELLIA_256_CBC_SHA,
+@@ -1651,6 +1701,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      256,
+      256,
+      },
++#endif
+ 
+     /* Cipher 87 */
+     {
+@@ -1703,6 +1754,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ 
+ #ifndef OPENSSL_NO_PSK
+     /* Cipher 8A */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_PSK_WITH_RC4_128_SHA,
+@@ -1717,8 +1769,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 8B */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_PSK_WITH_3DES_EDE_CBC_SHA,
+@@ -1733,6 +1787,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+     /* Cipher 8C */
+     {
+@@ -1787,6 +1842,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      },
+ 
+     /* Cipher 97 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_SEED_SHA,
+@@ -1801,8 +1857,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 98 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_SEED_SHA,
+@@ -1817,6 +1875,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher 99 */
+     {
+@@ -1935,6 +1994,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      },
+ 
+     /* Cipher A0 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_AES_128_GCM_SHA256,
+@@ -1949,8 +2009,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher A1 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_RSA_WITH_AES_256_GCM_SHA384,
+@@ -1965,6 +2027,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      256,
+      256,
+      },
++#endif
+ 
+     /* Cipher A2 */
+     {
+@@ -1999,6 +2062,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      },
+ 
+     /* Cipher A4 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_AES_128_GCM_SHA256,
+@@ -2013,8 +2077,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher A5 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_DH_DSS_WITH_AES_256_GCM_SHA384,
+@@ -2029,6 +2095,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      256,
+      256,
+      },
++#endif
+ 
+     /* Cipher A6 */
+     {
+@@ -2095,6 +2162,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      },
+ 
+     /* Cipher C002 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_ECDH_ECDSA_WITH_RC4_128_SHA,
+@@ -2109,8 +2177,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher C003 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_ECDH_ECDSA_WITH_DES_192_CBC3_SHA,
+@@ -2125,6 +2195,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+     /* Cipher C004 */
+     {
+@@ -2175,6 +2246,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      },
+ 
+     /* Cipher C007 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_ECDHE_ECDSA_WITH_RC4_128_SHA,
+@@ -2189,8 +2261,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher C008 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_ECDHE_ECDSA_WITH_DES_192_CBC3_SHA,
+@@ -2205,6 +2279,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+     /* Cipher C009 */
+     {
+@@ -2255,6 +2330,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      },
+ 
+     /* Cipher C00C */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_ECDH_RSA_WITH_RC4_128_SHA,
+@@ -2269,8 +2345,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher C00D */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_ECDH_RSA_WITH_DES_192_CBC3_SHA,
+@@ -2285,6 +2363,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+     /* Cipher C00E */
+     {
+@@ -2335,6 +2414,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      },
+ 
+     /* Cipher C011 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_ECDHE_RSA_WITH_RC4_128_SHA,
+@@ -2349,8 +2429,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher C012 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_ECDHE_RSA_WITH_DES_192_CBC3_SHA,
+@@ -2365,6 +2447,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+     /* Cipher C013 */
+     {
+@@ -2415,6 +2498,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      },
+ 
+     /* Cipher C016 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_ECDH_anon_WITH_RC4_128_SHA,
+@@ -2429,8 +2513,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      128,
+      128,
+      },
++#endif
+ 
+     /* Cipher C017 */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_ECDH_anon_WITH_DES_192_CBC3_SHA,
+@@ -2445,6 +2531,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+     /* Cipher C018 */
+     {
+@@ -2481,6 +2568,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+ 
+ #ifndef OPENSSL_NO_SRP
+     /* Cipher C01A */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_SRP_SHA_WITH_3DES_EDE_CBC_SHA,
+@@ -2495,8 +2583,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+     /* Cipher C01B */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA,
+@@ -2511,8 +2601,10 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+     /* Cipher C01C */
++#ifndef OPENSSL_NO_WEAK_SSL_CIPHERS
+     {
+      1,
+      TLS1_TXT_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA,
+@@ -2527,6 +2619,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[]
+      112,
+      168,
+      },
++#endif
+ 
+     /* Cipher C01D */
+     {

--- a/openssl1x/Patches/0008-CVE-2020-1971.patch
+++ b/openssl1x/Patches/0008-CVE-2020-1971.patch
@@ -1,0 +1,79 @@
+diff -wpruN '--exclude=*.orig' a~/crypto/x509v3/v3_genn.c a/crypto/x509v3/v3_genn.c
+--- a~/crypto/x509v3/v3_genn.c	1970-01-01 00:00:00
++++ a/crypto/x509v3/v3_genn.c	1970-01-01 00:00:00
+@@ -107,6 +107,37 @@ GENERAL_NAME *GENERAL_NAME_dup(GENERAL_N
+                                     (char *)a);
+ }
+ 
++static int edipartyname_cmp(const EDIPARTYNAME *a, const EDIPARTYNAME *b)
++{
++    int res;
++
++    if (a == NULL || b == NULL) {
++        /*
++         * Shouldn't be possible in a valid GENERAL_NAME, but we handle it
++         * anyway. OTHERNAME_cmp treats NULL != NULL so we do the same here
++         */
++        return -1;
++    }
++    if (a->nameAssigner == NULL && b->nameAssigner != NULL)
++        return -1;
++    if (a->nameAssigner != NULL && b->nameAssigner == NULL)
++        return 1;
++    /* If we get here then both have nameAssigner set, or both unset */
++    if (a->nameAssigner != NULL) {
++        res = ASN1_STRING_cmp(a->nameAssigner, b->nameAssigner);
++        if (res != 0)
++            return res;
++    }
++    /*
++     * partyName is required, so these should never be NULL. We treat it in
++     * the same way as the a == NULL || b == NULL case above
++     */
++    if (a->partyName == NULL || b->partyName == NULL)
++        return -1;
++
++    return ASN1_STRING_cmp(a->partyName, b->partyName);
++}
++
+ /* Returns 0 if they are equal, != 0 otherwise. */
+ int GENERAL_NAME_cmp(GENERAL_NAME *a, GENERAL_NAME *b)
+ {
+@@ -116,8 +147,11 @@ int GENERAL_NAME_cmp(GENERAL_NAME *a, GE
+         return -1;
+     switch (a->type) {
+     case GEN_X400:
++        result = ASN1_TYPE_cmp(a->d.x400Address, b->d.x400Address);
++        break;
++
+     case GEN_EDIPARTY:
+-        result = ASN1_TYPE_cmp(a->d.other, b->d.other);
++        result = edipartyname_cmp(a->d.ediPartyName, b->d.ediPartyName);
+         break;
+ 
+     case GEN_OTHERNAME:
+@@ -164,8 +198,11 @@ void GENERAL_NAME_set0_value(GENERAL_NAM
+ {
+     switch (type) {
+     case GEN_X400:
++	a->d.x400Address = value;
++	break;
++
+     case GEN_EDIPARTY:
+-        a->d.other = value;
++        a->d.ediPartyName = value;
+         break;
+ 
+     case GEN_OTHERNAME:
+@@ -199,8 +236,10 @@ void *GENERAL_NAME_get0_value(GENERAL_NA
+         *ptype = a->type;
+     switch (a->type) {
+     case GEN_X400:
++	return a->d.x400Address;
++
+     case GEN_EDIPARTY:
+-        return a->d.other;
++        return a->d.ediPartyName;
+ 
+     case GEN_OTHERNAME:
+         return a->d.otherName;


### PR DESCRIPTION
Seems to compile okay, but will need some smoke-testing.  NOTE:  Eliminates RC4 and 3DES as supported.