### PR TITLE
OS-8313 Addition of memrchr breaks illumos-extra gnupg build

### DIFF
--- a/gnupg/Patches/0002-OS-8313-do-not-check.patch
+++ b/gnupg/Patches/0002-OS-8313-do-not-check.patch
@@ -1,0 +1,16 @@
+Remove checks from build-time for now, because gnupg needs to be able to cope
+with the idea of a proto area's library for testing the freshly-compiled binary.
+
+diff -ru gnupg-1.4.11/Makefile.in gnupg-1.4.11-OS-8313-1/Makefile.in
+--- gnupg-1.4.11/Makefile.in    Mon Oct 18 05:53:58 2010
++++ gnupg-1.4.11-OS-8313-1/Makefile.in  Wed Aug 25 00:27:47 2021
+@@ -291,8 +291,7 @@
+ # selinux-support is enabled.
+ DISTCHECK_CONFIGURE_FLAGS = --enable-mailto
+ AUTOMAKE_OPTIONS = dist-bzip2 filename-length-max=99
+-@CROSS_COMPILING_FALSE@checks = checks
+-@CROSS_COMPILING_TRUE@checks = 
++checks = 
+ SUBDIRS = m4 intl zlib util mpi cipher tools g10 keyserver po doc ${checks}
+ EXTRA_DIST = scripts/config.rpath  PROJECTS BUGS config.h.in autogen.sh
+ DISTCLEANFILES = 


### PR DESCRIPTION
This is "solution 1" where we just get rid of running the post-compile checks.  It is not wonderful, but it may get us over the can't-build-smartos-live hump.