### PR TITLE
OS-8313 Addition of memrchr breaks illumos-extra gnupg build

### DIFF
--- a/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
+++ b/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
@@ -2,19 +2,19 @@ For these checks, use the libraries in the proto area, in case we add a new
 symbol to libc or friends that gnupg's `configure` picks up.
 
 diff -ru gnupg-1.4.11/checks/Makefile.in gnupg-1.4.11-OS-8313-2/checks/Makefile.in
---- gnupg-1.4.11/checks/Makefile.in     Mon Oct 18 05:53:57 2010
-+++ gnupg-1.4.11-OS-8313-2/checks/Makefile.in   Wed Aug 25 01:41:34 2021
+--- gnupg-1.4.11/checks/Makefile.in	Mon Oct 18 05:53:57 2010
++++ gnupg-1.4.11-OS-8313-2/checks/Makefile.in	Wed Aug 25 01:41:34 2021
 @@ -543,6 +543,7 @@
  
  ./gpg_dearmor:
-        echo '#!/bin/sh' >./gpg_dearmor
-+       echo 'LD_LIBRARY_PATH=`pwd`/../../../../../usr/lib' >>./gpg_dearmor
-        echo "../g10/gpg --no-options --no-greeting \
+ 	echo '#!/bin/sh' >./gpg_dearmor
++	echo 'LD_LIBRARY_PATH=`pwd`/../../../../../usr/lib' >>./gpg_dearmor
+ 	echo "../g10/gpg --no-options --no-greeting \
               --no-secmem-warning --batch --dearmor" >>./gpg_dearmor
-        chmod 755 ./gpg_dearmor
+ 	chmod 755 ./gpg_dearmor
 diff -ru gnupg-1.4.11/checks/defs.inc gnupg-1.4.11-OS-8313-2/checks/defs.inc
---- gnupg-1.4.11/checks/defs.inc        Thu Aug 13 03:29:18 2009
-+++ gnupg-1.4.11-OS-8313-2/checks/defs.inc      Wed Aug 25 01:06:48 2021
+--- gnupg-1.4.11/checks/defs.inc	Thu Aug 13 03:29:18 2009
++++ gnupg-1.4.11-OS-8313-2/checks/defs.inc	Wed Aug 25 01:06:48 2021
 @@ -31,6 +31,10 @@
  LC_ALL=
  LC_MESSAGES=

--- a/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
+++ b/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
@@ -4,7 +4,7 @@ symbol to libc or friends that gnupg's `configure` picks up.
 diff -ru gnupg-1.4.11/checks/Makefile.in gnupg-1.4.11-OS-8313-2/checks/Makefile.in
 --- gnupg-1.4.11/checks/Makefile.in	Mon Oct 18 05:53:57 2010
 +++ gnupg-1.4.11-OS-8313-2/checks/Makefile.in	Wed Aug 25 01:41:34 2021
-@@ -543,6 +543,7 @@
+@@ -543,6 +543,8 @@
  
  ./gpg_dearmor:
  	echo '#!/bin/sh' >./gpg_dearmor

--- a/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
+++ b/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
@@ -1,0 +1,17 @@
+For these checks, use the libraries in the proto area, in case we add a new
+symbol to libc or friends that gnupg's `configure` picks up.
+
+diff -ru /tmp/gnupg-1.4.11/checks/defs.inc /tmp/gnupg-1.4.11-OS-8313-2//checks/defs.inc
+--- /tmp/gnupg-1.4.11/checks/defs.inc   Thu Aug 13 03:29:18 2009
++++ /tmp/gnupg-1.4.11-OS-8313-2//checks/defs.inc        Wed Aug 25 01:06:48 2021
+@@ -31,6 +31,10 @@
+ LC_ALL=
+ LC_MESSAGES=
+ 
++# As part of a smartos-live build, set the LD_LIBRARY_PATH to the smartos-live
++# proto area.
++LD_LIBRARY_PATH=$PWD/../../../../../proto/usr/lib
++
+ # Internal use.
+ defs_stop_on_error=no
+ defs_error_seen=no

--- a/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
+++ b/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
@@ -19,7 +19,7 @@ diff -ru gnupg-1.4.11/checks/Makefile.in gnupg-1.4.11-OS-8313-2/checks/Makefile.
 +	echo '#!/bin/sh' >./gpg_import
 +	echo 'LD_LIBRARY_PATH=`pwd`/../../../../../proto/usr/lib' >>./gpg_import
 +	echo 'export LD_LIBRARY_PATH' >>./gpg_import
-+	echo $(GPG_IMPORT) "\$1" >>./gpg_import
++	echo '$(GPG_IMPORT) $$1' >>./gpg_import
 +	chmod 755 ./gpg_import
 +
  ./gpg_dearmor:

--- a/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
+++ b/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
@@ -1,9 +1,9 @@
 For these checks, use the libraries in the proto area, in case we add a new
 symbol to libc or friends that gnupg's `configure` picks up.
 
-diff -ru /tmp/gnupg-1.4.11/checks/defs.inc /tmp/gnupg-1.4.11-OS-8313-2//checks/defs.inc
---- /tmp/gnupg-1.4.11/checks/defs.inc   Thu Aug 13 03:29:18 2009
-+++ /tmp/gnupg-1.4.11-OS-8313-2//checks/defs.inc        Wed Aug 25 01:06:48 2021
+diff -ru gnupg-1.4.11/checks/defs.inc gnupg-1.4.11-OS-8313-2/checks/defs.inc
+--- gnupg-1.4.11/checks/defs.inc   Thu Aug 13 03:29:18 2009
++++ gnupg-1.4.11-OS-8313-2/checks/defs.inc        Wed Aug 25 01:06:48 2021
 @@ -31,6 +31,10 @@
  LC_ALL=
  LC_MESSAGES=

--- a/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
+++ b/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
@@ -19,7 +19,7 @@ diff -ru gnupg-1.4.11/checks/Makefile.in gnupg-1.4.11-OS-8313-2/checks/Makefile.
 +	echo '#!/bin/sh' >./gpg_import
 +	echo 'LD_LIBRARY_PATH=`pwd`/../../../../../proto/usr/lib' >>./gpg_import
 +	echo 'export LD_LIBRARY_PATH' >>./gpg_import
-+	echo $(GPG_IMPORT) '$1' >>./gpg_import
++	echo $(GPG_IMPORT) "\$1" >>./gpg_import
 +	chmod 755 ./gpg_import
 +
  ./gpg_dearmor:

--- a/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
+++ b/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
@@ -1,9 +1,20 @@
 For these checks, use the libraries in the proto area, in case we add a new
 symbol to libc or friends that gnupg's `configure` picks up.
 
+diff -ru gnupg-1.4.11/checks/Makefile.in gnupg-1.4.11-OS-8313-2/checks/Makefile.in
+--- gnupg-1.4.11/checks/Makefile.in     Mon Oct 18 05:53:57 2010
++++ gnupg-1.4.11-OS-8313-2/checks/Makefile.in   Wed Aug 25 01:41:34 2021
+@@ -543,6 +543,7 @@
+ 
+ ./gpg_dearmor:
+        echo '#!/bin/sh' >./gpg_dearmor
++       echo 'LD_LIBRARY_PATH=`pwd`/../../../../../usr/lib' >>./gpg_dearmor
+        echo "../g10/gpg --no-options --no-greeting \
+              --no-secmem-warning --batch --dearmor" >>./gpg_dearmor
+        chmod 755 ./gpg_dearmor
 diff -ru gnupg-1.4.11/checks/defs.inc gnupg-1.4.11-OS-8313-2/checks/defs.inc
---- gnupg-1.4.11/checks/defs.inc   Thu Aug 13 03:29:18 2009
-+++ gnupg-1.4.11-OS-8313-2/checks/defs.inc        Wed Aug 25 01:06:48 2021
+--- gnupg-1.4.11/checks/defs.inc        Thu Aug 13 03:29:18 2009
++++ gnupg-1.4.11-OS-8313-2/checks/defs.inc      Wed Aug 25 01:06:48 2021
 @@ -31,6 +31,10 @@
  LC_ALL=
  LC_MESSAGES=

--- a/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
+++ b/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
@@ -9,6 +9,7 @@ diff -ru gnupg-1.4.11/checks/Makefile.in gnupg-1.4.11-OS-8313-2/checks/Makefile.
  ./gpg_dearmor:
  	echo '#!/bin/sh' >./gpg_dearmor
 +	echo 'LD_LIBRARY_PATH=`pwd`/../../../../../proto/usr/lib' >>./gpg_dearmor
++	echo 'export LD_LIBRARY_PATH' >>./gpg_dearmor
  	echo "../g10/gpg --no-options --no-greeting \
               --no-secmem-warning --batch --dearmor" >>./gpg_dearmor
  	chmod 755 ./gpg_dearmor

--- a/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
+++ b/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
@@ -3,9 +3,25 @@ symbol to libc or friends that gnupg's `configure` picks up.
 
 diff -ru gnupg-1.4.11/checks/Makefile.in gnupg-1.4.11-OS-8313-2/checks/Makefile.in
 --- gnupg-1.4.11/checks/Makefile.in	Mon Oct 18 05:53:57 2010
-+++ gnupg-1.4.11-OS-8313-2/checks/Makefile.in	Wed Aug 25 01:41:34 2021
-@@ -543,6 +543,8 @@
++++ gnupg-1.4.11-OS-8313-2/checks/Makefile.in	Wed Aug 25 02:18:10 2021
+@@ -537,12 +537,22 @@
+ 	$(srcdir)/mkdemodirs --clean
  
+ prepared.stamp: ./pubring.gpg ./secring.gpg ./plain-1 ./plain-2 ./plain-3 \
+-		./pubring.pkr ./secring.skr ./gpg_dearmor $(DATA_FILES)
+-	 $(GPG_IMPORT) $(srcdir)/pubdemo.asc	 
++		./pubring.pkr ./secring.skr ./gpg_dearmor ./gpg_import \
++		$(DATA_FILES)
++	 ./gpg_import $(srcdir)/pubdemo.asc	 
+ 	 echo timestamp >./prepared.stamp
+ 
++./gpg_import:
++	echo '#!/bin/sh' >./gpg_import
++	echo 'LD_LIBRARY_PATH=`pwd`/../../../../../proto/usr/lib' >>./gpg_import
++	echo 'export LD_LIBRARY_PATH' >>./gpg_import
++	echo $(GPG_IMPORT) '$1' >>./gpg_import
++	chmod 755 ./gpg_import
++
  ./gpg_dearmor:
  	echo '#!/bin/sh' >./gpg_dearmor
 +	echo 'LD_LIBRARY_PATH=`pwd`/../../../../../proto/usr/lib' >>./gpg_dearmor

--- a/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
+++ b/gnupg/Patches/0002-OS-8313-use-proto-libs.patch
@@ -8,7 +8,7 @@ diff -ru gnupg-1.4.11/checks/Makefile.in gnupg-1.4.11-OS-8313-2/checks/Makefile.
  
  ./gpg_dearmor:
  	echo '#!/bin/sh' >./gpg_dearmor
-+	echo 'LD_LIBRARY_PATH=`pwd`/../../../../../usr/lib' >>./gpg_dearmor
++	echo 'LD_LIBRARY_PATH=`pwd`/../../../../../proto/usr/lib' >>./gpg_dearmor
  	echo "../g10/gpg --no-options --no-greeting \
               --no-secmem-warning --batch --dearmor" >>./gpg_dearmor
  	chmod 755 ./gpg_dearmor


### PR DESCRIPTION
This is "solution 2" where we force the gnupg "checks" scripts to add the smartos-live proto area's usr/lib to its LD_LIBRARY_PATH.  This is untested as of the PR creation.