### PR TITLE
OS-8314 Address CVE-2021-3712 for OpenSSL 1.0.2 in illumos-extra

### DIFF
--- a/openssl1x/Patches/0013-CVE-2021-3712.patch
+++ b/openssl1x/Patches/0013-CVE-2021-3712.patch
@@ -1,0 +1,379 @@
+diff -ru openssl-1.0.2u-64/apps/x509.c openssl-1.0.2u-64-new/apps/x509.c
+--- openssl-1.0.2u-64/apps/x509.c	Fri Dec 20 08:02:41 2019
++++ openssl-1.0.2u-64-new/apps/x509.c	Thu Sep  2 17:08:03 2021
+@@ -749,9 +749,9 @@
+                 X509_email_free(emlst);
+             } else if (aliasout == i) {
+                 unsigned char *alstr;
+-                alstr = X509_alias_get0(x, NULL);
++                alstr = X509_alias_get0(x, &i);
+                 if (alstr)
+-                    BIO_printf(STDout, "%s\n", alstr);
++                    BIO_printf(STDout, "%.*s\n", i, alstr);
+                 else
+                     BIO_puts(STDout, "<No Alias>\n");
+             } else if (subject_hash == i) {
+diff -ru openssl-1.0.2u-64/crypto/asn1/t_spki.c openssl-1.0.2u-64-new/crypto/asn1/t_spki.c
+--- openssl-1.0.2u-64/crypto/asn1/t_spki.c	Fri Dec 20 08:02:41 2019
++++ openssl-1.0.2u-64-new/crypto/asn1/t_spki.c	Thu Sep  2 17:08:03 2021
+@@ -90,7 +90,7 @@
+     }
+     chal = spki->spkac->challenge;
+     if (chal->length)
+-        BIO_printf(out, "  Challenge String: %s\n", chal->data);
++        BIO_printf(out, "  Challenge String: %.*s\n", chal->length, chal->data);
+     i = OBJ_obj2nid(spki->sig_algor->algorithm);
+     BIO_printf(out, "  Signature Algorithm: %s",
+                (i == NID_undef) ? "UNKNOWN" : OBJ_nid2ln(i));
+diff -ru openssl-1.0.2u-64/crypto/ec/ec_asn1.c openssl-1.0.2u-64-new/crypto/ec/ec_asn1.c
+--- openssl-1.0.2u-64/crypto/ec/ec_asn1.c	Fri Dec 20 08:02:41 2019
++++ openssl-1.0.2u-64-new/crypto/ec/ec_asn1.c	Thu Sep  2 17:08:03 2021
+@@ -867,7 +867,8 @@
+         ret->seed_len = params->curve->seed->length;
+     }
+ 
+-    if (!params->order || !params->base || !params->base->data) {
++    if (!params->order || !params->base || !params->base->data ||
++		    params->base->length == 0) {
+         ECerr(EC_F_EC_ASN1_PARAMETERS2GROUP, EC_R_ASN1_ERROR);
+         goto err;
+     }
+diff -ru openssl-1.0.2u-64/crypto/x509v3/v3_alt.c openssl-1.0.2u-64-new/crypto/x509v3/v3_alt.c
+--- openssl-1.0.2u-64/crypto/x509v3/v3_alt.c	Fri Dec 20 08:02:41 2019
++++ openssl-1.0.2u-64-new/crypto/x509v3/v3_alt.c	Thu Sep  2 17:08:45 2021
+@@ -134,17 +134,20 @@
+         break;
+ 
+     case GEN_EMAIL:
+-        if (!X509V3_add_value_uchar("email", gen->d.ia5->data, &ret))
++        if (!x509v3_add_len_value_uchar("email", gen->d.ia5->data,
++		gen->d.ia5->length, &ret))
+             return NULL;
+         break;
+ 
+     case GEN_DNS:
+-        if (!X509V3_add_value_uchar("DNS", gen->d.ia5->data, &ret))
++        if (!x509v3_add_len_value_uchar("DNS", gen->d.ia5->data,
++		gen->d.ia5->length, &ret))
+             return NULL;
+         break;
+ 
+     case GEN_URI:
+-        if (!X509V3_add_value_uchar("URI", gen->d.ia5->data, &ret))
++        if (!x509v3_add_len_value_uchar("URI", gen->d.ia5->data,
++		gen->d.ia5->length, &ret))
+             return NULL;
+         break;
+ 
+diff -ru openssl-1.0.2u-64/crypto/x509v3/v3_cpols.c openssl-1.0.2u-64-new/crypto/x509v3/v3_cpols.c
+--- openssl-1.0.2u-64/crypto/x509v3/v3_cpols.c	Fri Dec 20 08:02:41 2019
++++ openssl-1.0.2u-64-new/crypto/x509v3/v3_cpols.c	Thu Sep  2 17:08:03 2021
+@@ -423,7 +423,8 @@
+         qualinfo = sk_POLICYQUALINFO_value(quals, i);
+         switch (OBJ_obj2nid(qualinfo->pqualid)) {
+         case NID_id_qt_cps:
+-            BIO_printf(out, "%*sCPS: %s\n", indent, "",
++            BIO_printf(out, "%*sCPS: %.*s\n", indent, "",
++                       qualinfo->d.cpsuri->length,
+                        qualinfo->d.cpsuri->data);
+             break;
+ 
+@@ -448,7 +449,8 @@
+     if (notice->noticeref) {
+         NOTICEREF *ref;
+         ref = notice->noticeref;
+-        BIO_printf(out, "%*sOrganization: %s\n", indent, "",
++        BIO_printf(out, "%*sOrganization: %.*s\n", indent, "",
++                   ref->organization->length,
+                    ref->organization->data);
+         BIO_printf(out, "%*sNumber%s: ", indent, "",
+                    sk_ASN1_INTEGER_num(ref->noticenos) > 1 ? "s" : "");
+@@ -471,7 +473,8 @@
+         BIO_puts(out, "\n");
+     }
+     if (notice->exptext)
+-        BIO_printf(out, "%*sExplicit Text: %s\n", indent, "",
++        BIO_printf(out, "%*sExplicit Text: %.*s\n", indent, "",
++                   notice->exptext->length,
+                    notice->exptext->data);
+ }
+ 
+diff -ru openssl-1.0.2u-64/crypto/x509v3/v3_ncons.c openssl-1.0.2u-64-new/crypto/x509v3/v3_ncons.c
+--- openssl-1.0.2u-64/crypto/x509v3/v3_ncons.c	Fri Dec 20 08:02:41 2019
++++ openssl-1.0.2u-64-new/crypto/x509v3/v3_ncons.c	Thu Sep  2 17:08:03 2021
+@@ -107,8 +107,33 @@
+ IMPLEMENT_ASN1_ALLOC_FUNCTIONS(GENERAL_SUBTREE)
+ IMPLEMENT_ASN1_ALLOC_FUNCTIONS(NAME_CONSTRAINTS)
+ 
++
++#define IA5_OFFSET_LEN(ia5base, offset) \
++    ((ia5base)->length - ((unsigned char *)(offset) - (ia5base)->data))
++
++/* Like memchr but for ASN1_IA5STRING. Additionally you can specify the
++ * starting point to search from
++ */
++# define ia5memchr(str, start, c) memchr(start, c, IA5_OFFSET_LEN(str, start))
++
++/* Like memrrchr but for ASN1_IA5STRING */
++static char *ia5memrchr(ASN1_IA5STRING *str, int c)
++{
++    int i;
++
++    for (i = str->length; i > 0 && str->data[i - 1] != c; i--);
++
++    if (i == 0)
++        return NULL;
++
++    return (char *)&str->data[i - 1];
++}
++
++
++
+ /*
+- * We cannot use strncasecmp here because that applies locale specific rules.
++ * We cannot use strncasecmp here because that applies locale specific rules. It
++ * also doesn't work with ASN1_STRINGs that may have embedded NUL characters.
+  * For example in Turkish 'I' is not the uppercase character for 'i'. We need to
+  * do a simple ASCII case comparison ignoring the locale (that is why we use
+  * numeric constants below).
+@@ -133,9 +158,6 @@
+ 
+             /* c1 > c2 */
+             return 1;
+-        } else if (*s1 == 0) {
+-            /* If we get here we know that *s2 == 0 too */
+-            return 0;
+         }
+     }
+ 
+@@ -142,12 +164,6 @@
+     return 0;
+ }
+ 
+-static int ia5casecmp(const char *s1, const char *s2)
+-{
+-    /* No portable definition of SIZE_MAX, so we use (size_t)(-1) instead */
+-    return ia5ncasecmp(s1, s2, (size_t)(-1));
+-}
+-
+ static void *v2i_NAME_CONSTRAINTS(const X509V3_EXT_METHOD *method,
+                                   X509V3_CTX *ctx, STACK_OF(CONF_VALUE) *nval)
+ {
+@@ -413,8 +429,10 @@
+     char *baseptr = (char *)base->data;
+     char *dnsptr = (char *)dns->data;
+     /* Empty matches everything */
+-    if (!*baseptr)
++    if (base->length == 0)
+         return X509_V_OK;
++    if (dns->length < base->length)
++	    return X509_V_ERR_PERMITTED_VIOLATION;
+     /*
+      * Otherwise can add zero or more components on the left so compare RHS
+      * and if dns is longer and expect '.' as preceding character.
+@@ -425,7 +443,7 @@
+             return X509_V_ERR_PERMITTED_VIOLATION;
+     }
+ 
+-    if (ia5casecmp(baseptr, dnsptr))
++    if (ia5ncasecmp(baseptr, dnsptr, base->length))
+         return X509_V_ERR_PERMITTED_VIOLATION;
+ 
+     return X509_V_OK;
+@@ -436,16 +454,17 @@
+ {
+     const char *baseptr = (char *)base->data;
+     const char *emlptr = (char *)eml->data;
++    const char *baseat = ia5memrchr(base, '@');
++    const char *emlat = ia5memrchr(eml, '@');
++    size_t basehostlen, emlhostlen;
+ 
+-    const char *baseat = strchr(baseptr, '@');
+-    const char *emlat = strchr(emlptr, '@');
+     if (!emlat)
+         return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
+     /* Special case: inital '.' is RHS match */
+-    if (!baseat && (*baseptr == '.')) {
++    if (!baseat && base->length > 0 && (*baseptr == '.')) {
+         if (eml->length > base->length) {
+             emlptr += eml->length - base->length;
+-            if (ia5casecmp(baseptr, emlptr) == 0)
++            if (ia5ncasecmp(baseptr, emlptr, base->length) == 0)
+                 return X509_V_OK;
+         }
+         return X509_V_ERR_PERMITTED_VIOLATION;
+@@ -465,8 +484,10 @@
+         baseptr = baseat + 1;
+     }
+     emlptr = emlat + 1;
++    basehostlen = IA5_OFFSET_LEN(base, baseptr);
++    emlhostlen = IA5_OFFSET_LEN(eml, emlptr);
+     /* Just have hostname left to match: case insensitive */
+-    if (ia5casecmp(baseptr, emlptr))
++    if (basehostlen != emlhostlen || ia5ncasecmp(baseptr, emlptr, emlhostlen))
+         return X509_V_ERR_PERMITTED_VIOLATION;
+ 
+     return X509_V_OK;
+@@ -477,10 +498,11 @@
+ {
+     const char *baseptr = (char *)base->data;
+     const char *hostptr = (char *)uri->data;
+-    const char *p = strchr(hostptr, ':');
++    const char *p = ia5memchr(uri, (char *)uri->data, ':');
+     int hostlen;
++
+     /* Check for foo:// and skip past it */
+-    if (!p || (p[1] != '/') || (p[2] != '/'))
++    if (!p || IA5_OFFSET_LEN(uri, p) < 3 || (p[1] != '/') || (p[2] != '/'))
+         return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
+     hostptr = p + 3;
+ 
+@@ -488,13 +510,13 @@
+ 
+     /* Look for a port indicator as end of hostname first */
+ 
+-    p = strchr(hostptr, ':');
++    p = ia5memchr(uri, hostptr, ':');
+     /* Otherwise look for trailing slash */
+     if (!p)
+-        p = strchr(hostptr, '/');
++        p = ia5memchr(uri, hostptr, '/');
+ 
+     if (!p)
+-        hostlen = strlen(hostptr);
++        hostlen = IA5_OFFSET_LEN(uri, hostptr);
+     else
+         hostlen = p - hostptr;
+ 
+@@ -502,7 +524,7 @@
+         return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
+ 
+     /* Special case: inital '.' is RHS match */
+-    if (*baseptr == '.') {
++    if (base->length > 0 && *baseptr == '.') {
+         if (hostlen > base->length) {
+             p = hostptr + hostlen - base->length;
+             if (ia5ncasecmp(p, baseptr, base->length) == 0)
+diff -ru openssl-1.0.2u-64/crypto/x509v3/v3_pci.c openssl-1.0.2u-64-new/crypto/x509v3/v3_pci.c
+--- openssl-1.0.2u-64/crypto/x509v3/v3_pci.c	Fri Dec 20 08:02:41 2019
++++ openssl-1.0.2u-64-new/crypto/x509v3/v3_pci.c	Thu Sep  2 17:08:03 2021
+@@ -68,7 +68,8 @@
+     i2a_ASN1_OBJECT(out, pci->proxyPolicy->policyLanguage);
+     BIO_puts(out, "\n");
+     if (pci->proxyPolicy->policy && pci->proxyPolicy->policy->data)
+-        BIO_printf(out, "%*sPolicy Text: %s\n", indent, "",
++        BIO_printf(out, "%*sPolicy Text: %.*s\n", indent, "",
++                   pci->proxyPolicy->policy->length,
+                    pci->proxyPolicy->policy->data);
+     return 1;
+ }
+diff -ru openssl-1.0.2u-64/crypto/x509v3/v3_utl.c openssl-1.0.2u-64-new/crypto/x509v3/v3_utl.c
+--- openssl-1.0.2u-64/crypto/x509v3/v3_utl.c	Fri Dec 20 08:02:41 2019
++++ openssl-1.0.2u-64-new/crypto/x509v3/v3_utl.c	Thu Sep  2 17:08:03 2021
+@@ -59,6 +59,7 @@
+ /* X509 v3 extension utilities */
+ 
+ #include <stdio.h>
++#include <string.h>
+ #include <ctype.h>
+ #include "cryptlib.h"
+ #include <openssl/conf.h>
+@@ -79,15 +80,24 @@
+ 
+ /* Add a CONF_VALUE name value pair to stack */
+ 
+-int X509V3_add_value(const char *name, const char *value,
+-                     STACK_OF(CONF_VALUE) **extlist)
++static int x509v3_add_len_value(const char *name, const char *value,
++                     size_t vallen, STACK_OF(CONF_VALUE) **extlist)
+ {
+     CONF_VALUE *vtmp = NULL;
+     char *tname = NULL, *tvalue = NULL;
+-    if (name && !(tname = BUF_strdup(name)))
++    if (name != NULL && (tname = BUF_strdup(name)) == NULL)
+         goto err;
+-    if (value && !(tvalue = BUF_strdup(value)))
+-        goto err;
++    if (value != NULL && vallen > 0) {
++	/*
++	 * We tolerate a single trailing NUL character, but otherwise no
++	 * embedded NULs
++	 */
++	if (memchr(value, 0, vallen - 1) != NULL)
++	    goto err;
++	tvalue = BUF_strndup(value, vallen);
++	if (tvalue == NULL)
++	    goto err;
++    }
+     if (!(vtmp = (CONF_VALUE *)OPENSSL_malloc(sizeof(CONF_VALUE))))
+         goto err;
+     if (!*extlist && !(*extlist = sk_CONF_VALUE_new_null()))
+@@ -109,12 +119,27 @@
+     return 0;
+ }
+ 
++int X509V3_add_value(const char *name, const char *value,
++                     STACK_OF(CONF_VALUE) **extlist)
++{
++	return x509v3_add_len_value(name, value,
++		value != NULL ? strlen((const char *)value) : 0, extlist);
++}
++
+ int X509V3_add_value_uchar(const char *name, const unsigned char *value,
+                            STACK_OF(CONF_VALUE) **extlist)
+ {
+-    return X509V3_add_value(name, (const char *)value, extlist);
++    return x509v3_add_len_value(name, (const char *)value,
++		   value != NULL ? strlen((const char *)value) : 0, extlist);
+ }
+ 
++int x509v3_add_len_value_uchar(const char *name, const unsigned char *value,
++		size_t vallen, STACK_OF(CONF_VALUE) **extlist)
++{
++    return x509v3_add_len_value(name, (const char *)value, vallen, extlist);
++}
++
++
+ /* Free function for STACK_OF(CONF_VALUE) */
+ 
+ void X509V3_conf_free(CONF_VALUE *conf)
+@@ -611,15 +636,22 @@
+         return 1;
+     if (!email->data || !email->length)
+         return 1;
++    if (memchr(email->data, 0, email->length) != NULL)
++	return 1;
+     if (!*sk)
+         *sk = sk_OPENSSL_STRING_new(sk_strcmp);
+     if (!*sk)
+         return 0;
++    emtmp = BUF_strndup((char *)email->data, email->length);
++    if (emtmp == NULL)
++	return 0;
+     /* Don't add duplicates */
+-    if (sk_OPENSSL_STRING_find(*sk, (char *)email->data) != -1)
++    if (sk_OPENSSL_STRING_find(*sk, emtmp) != -1) {
++	OPENSSL_free(emtmp);
+         return 1;
+-    emtmp = BUF_strdup((char *)email->data);
+-    if (!emtmp || !sk_OPENSSL_STRING_push(*sk, emtmp)) {
++    }
++    if (!sk_OPENSSL_STRING_push(*sk, emtmp)) {
++	OPENSSL_free(emtmp);
+         X509_email_free(*sk);
+         *sk = NULL;
+         return 0;
+diff -ru openssl-1.0.2u-64/crypto/x509v3/x509v3.h openssl-1.0.2u-64-new/crypto/x509v3/x509v3.h
+--- openssl-1.0.2u-64/crypto/x509v3/x509v3.h	Fri Dec 20 08:02:41 2019
++++ openssl-1.0.2u-64-new/crypto/x509v3/x509v3.h	Thu Sep  2 17:09:15 2021
+@@ -649,6 +649,10 @@
+ void X509V3_set_ctx(X509V3_CTX *ctx, X509 *issuer, X509 *subject,
+                     X509_REQ *req, X509_CRL *crl, int flags);
+ 
++/* XXX SmartOS patch for CVE-2021-3712 single external function prototype. */
++int x509v3_add_len_value_uchar(const char *name, const unsigned char *value,
++                size_t vallen, STACK_OF(CONF_VALUE) **extlist);
++
+ int X509V3_add_value(const char *name, const char *value,
+                      STACK_OF(CONF_VALUE) **extlist);
+ int X509V3_add_value_uchar(const char *name, const unsigned char *value,

--- a/openssl1x/sunw_prefix.h
+++ b/openssl1x/sunw_prefix.h
@@ -4798,6 +4798,7 @@
 #pragma redefine_extname	X509V3_add_value_bool_nf sunw_X509V3_add_value_bool_nf
 #pragma redefine_extname	X509V3_add_value_int sunw_X509V3_add_value_int
 #pragma redefine_extname	X509V3_add_value_uchar sunw_X509V3_add_value_uchar
+#pragma redefine_extname	x509v3_add_len_value_uchar sunw_x509v3_add_len_value_uchar
 #pragma redefine_extname	X509V3_add1_i2d sunw_X509V3_add1_i2d
 #pragma redefine_extname	X509V3_conf_free sunw_X509V3_conf_free
 #pragma redefine_extname	X509v3_delete_ext sunw_X509v3_delete_ext


### PR DESCRIPTION
Needs testing, builds successfully at least insofar as not holding up the rest of 0-extra-stamp.