### PR TITLE
OS-8320 Add CVE-2021-41617 patch to OpenSSH

### DIFF
--- a/openssh/Patches/0033-CVE-2021-41617.patch
+++ b/openssh/Patches/0033-CVE-2021-41617.patch
@@ -1,0 +1,25 @@
+From f3cbe43e28fe71427d41cfe3a17125b972710455 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Sun, 26 Sep 2021 14:01:03 +0000
+Subject: [PATCH] upstream: need initgroups() before setresgid(); reported by
+ anton@,
+
+ok deraadt@
+
+OpenBSD-Commit-ID: 6aa003ee658b316960d94078f2a16edbc25087ce
+diff -wpruN '--exclude=*.orig' a~/misc.c a/misc.c
+--- a~/misc.c	1970-01-01 00:00:00
++++ a/misc.c	1970-01-01 00:00:00
+@@ -2629,6 +2629,12 @@ subprocess(const char *tag, const char *
+ 		}
+ 		closefrom(STDERR_FILENO + 1);
+ 
++		if (geteuid() == 0 &&
++		    initgroups(pw->pw_name, pw->pw_gid) == -1) {
++			error("%s: initgroups(%s, %u): %s", tag,
++			    pw->pw_name, (u_int)pw->pw_gid, strerror(errno));
++			_exit(1);
++		}
+ 		if (setresgid(pw->pw_gid, pw->pw_gid, pw->pw_gid) == -1) {
+ 			error("%s: setresgid %u: %s", tag, (u_int)pw->pw_gid,
+ 			    strerror(errno));


### PR DESCRIPTION
Testing so far:  Modified locally built smartos-live to have this change, and performed the following reality check:

```
smartos-build-2(~/smartos-live)[1]% dis -F subprocess /usr/lib/ssh/sshd > /tmp/before
smartos-build-2(~/smartos-live)[0]% dis -F subprocess proto/usr/lib/ssh/sshd > /tmp/after
smartos-build-2(~/smartos-live)[0]% wc -l /tmp/{before,after}
     594 /tmp/before
     621 /tmp/after
    1215 total
smartos-build-2(~/smartos-live)[0]% grep call /tmp/before | wc -l
      60
smartos-build-2(~/smartos-live)[0]% grep call /tmp/after | wc -l
      63
smartos-build-2(~/smartos-live)[0]% 
```

The additional three `call` instructions should match the three additional function calls from the patch.