### PR TITLE
joyent/illumos-extra#63 openssh: DisableBanner patch mis-merged in 8.6

### DIFF
--- a/openssh/Patches/0001-Skip-config-check.patch
+++ b/openssh/Patches/0001-Skip-config-check.patch
@@ -1,7 +1,7 @@
 From 91ea963c6c6ba6a0f5bb0692d6248851cb903055 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:31:53 -0700
-Subject: [PATCH 01/34] Skip config check
+Subject: [PATCH 01/35] Skip config check
 
 #
 # This change is to remove some misleading error messages when running
@@ -37,5 +37,5 @@ index b749206d..61b9dffe 100644
  install-files:
  	$(MKDIR_P) $(DESTDIR)$(bindir)
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0002-PAM-Support.patch
+++ b/openssh/Patches/0002-PAM-Support.patch
@@ -1,7 +1,7 @@
 From 84c001ca5b32be663ec2e2a65632e0314d7e31b3 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:34:19 -0700
-Subject: [PATCH 02/34] PAM Support
+Subject: [PATCH 02/35] PAM Support
 
 #
 # To comply to the Solaris PAM policy, the UsePAM option is changed to be
@@ -50,5 +50,5 @@ index 4d1910fe..ac105537 100644
  	/* Standard Options */
  	case sBadOption:
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0003-lastlogin.patch
+++ b/openssh/Patches/0003-lastlogin.patch
@@ -1,7 +1,7 @@
 From 30964c803fb76014e75c560aed98cf2f9f336ad8 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:34:41 -0700
-Subject: [PATCH 03/34] lastlogin
+Subject: [PATCH 03/35] lastlogin
 
 *** old/servconf.c Wed Sep 17 02:54:26 2014
 ---
@@ -34,5 +34,5 @@ index 3b339aaf..01df6a67 100644
  .An -nosplit
  OpenSSH is a derivative of the original and free
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0004-Reorganise-man-pages-into-Illumos-numbering-adjust-t.patch
+++ b/openssh/Patches/0004-Reorganise-man-pages-into-Illumos-numbering-adjust-t.patch
@@ -1,7 +1,7 @@
 From db22e27dd6522a7ae8fc5a8dccf7f4afe8f21592 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:34:55 -0700
-Subject: [PATCH 04/34] Reorganise man pages into Illumos numbering, adjust
+Subject: [PATCH 04/35] Reorganise man pages into Illumos numbering, adjust
  text
 
 ---
@@ -1551,5 +1551,5 @@ index 01df6a67..ffbb527f 100644
  .Sh AUTHORS
  .An -nosplit
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0005-Deprecated-SunSSH-options.patch
+++ b/openssh/Patches/0005-Deprecated-SunSSH-options.patch
@@ -1,7 +1,7 @@
 From f956e645b6b0d3a28d2d97be8df3755a9d0ea2ff Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:35:12 -0700
-Subject: [PATCH 05/34] Deprecated SunSSH options
+Subject: [PATCH 05/35] Deprecated SunSSH options
 
 #
 # To make the transition from SunSSH to OpenSSH as smooth as possible, we
@@ -45,5 +45,5 @@ index 0f27652b..1e31f00c 100644
  };
  
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0006-GSS-store-creds-for-Solaris.patch
+++ b/openssh/Patches/0006-GSS-store-creds-for-Solaris.patch
@@ -1,7 +1,7 @@
 From ef1e430bd04b93300422b08e4683d093f57df394 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:35:34 -0700
-Subject: [PATCH 06/34] GSS store creds for Solaris
+Subject: [PATCH 06/35] GSS store creds for Solaris
 
 ---
  configure.ac    |  3 +++
@@ -188,5 +188,5 @@ index 5aa04d05..12879c49 100644
  #endif
  #ifdef USE_PAM
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0007-DTrace-support-for-SFTP.patch
+++ b/openssh/Patches/0007-DTrace-support-for-SFTP.patch
@@ -1,7 +1,7 @@
 From 6a338da33b57198deacf30f3649e9fcf1f03e704 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:35:43 -0700
-Subject: [PATCH 07/34] DTrace support for SFTP
+Subject: [PATCH 07/35] DTrace support for SFTP
 
 ---
  Makefile.in          | 22 +++++++++++--
@@ -365,5 +365,5 @@ index 00000000..4b18e6ec
 +
 +#endif /* _SFTP_PROVIDER_IMPL_H */
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0008-Add-DisableBanner-option.patch
+++ b/openssh/Patches/0008-Add-DisableBanner-option.patch
@@ -1,7 +1,7 @@
-From 986624a6c52a3c06d38b528bbfc2bb85c789bd9d Mon Sep 17 00:00:00 2001
+From fa997a0eb47eaebe4ac66a453d459dbf748d6297 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:36:00 -0700
-Subject: [PATCH 08/34] Add DisableBanner option
+Subject: [PATCH 08/35] Add DisableBanner option
 
 ---
  readconf.c    | 31 +++++++++++++++++++++++++++++++
@@ -135,7 +135,7 @@ index 1563aae3..2bcc365d 100644
  Specifies that a TCP port on the local machine be forwarded
  over the secure channel, and the application
 diff --git a/sshconnect2.c b/sshconnect2.c
-index a53ab95d..65f8e1c9 100644
+index a53ab95d..8573130e 100644
 --- a/sshconnect2.c
 +++ b/sshconnect2.c
 @@ -85,6 +85,10 @@ extern char *client_version_string;
@@ -143,7 +143,7 @@ index a53ab95d..65f8e1c9 100644
  extern Options options;
  
 +#ifdef DISABLE_BANNER
-+extern struct sshbuf command;
++extern struct sshbuf *command;
 +#endif
 +
  /*
@@ -154,7 +154,7 @@ index a53ab95d..65f8e1c9 100644
  input_userauth_banner(int type, u_int32_t seq, struct ssh *ssh)
  {
 -	char *msg = NULL;
-+	char *msg = NULL, *raw;
++	char *msg, *raw = NULL;
  	size_t len;
  	int r;
  
@@ -171,9 +171,9 @@ index a53ab95d..65f8e1c9 100644
 +	 * use DisableBanner option to decide whether to display it or not.
 +	 */
 +	if (len > 0 && options.log_level >= SYSLOG_LEVEL_INFO &&
-+            (options.disable_banner == SSH_DISABLEBANNER_NO ||
-+            (options.disable_banner == SSH_DISABLEBANNER_INEXECMODE)) &&
-+            sshbuf_len(&command) == 0) {
++	    (options.disable_banner == SSH_DISABLEBANNER_NO ||
++	    (options.disable_banner == SSH_DISABLEBANNER_INEXECMODE)) &&
++	    command != NULL && sshbuf_len(command) == 0) {
 +#else
 +	if (len > 0 && options.log_level >= SYSLOG_LEVEL_INFO) {
 +#endif
@@ -192,5 +192,5 @@ index a53ab95d..65f8e1c9 100644
  }
  
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0009-PAM-conversation-fix.patch
+++ b/openssh/Patches/0009-PAM-conversation-fix.patch
@@ -1,7 +1,7 @@
-From ebeae41066726678e0dcb010d35b2787c6248f85 Mon Sep 17 00:00:00 2001
+From dfaff6e4c423c148840f631f50e9b980ff6ea743 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:36:13 -0700
-Subject: [PATCH 09/34] PAM conversation fix
+Subject: [PATCH 09/35] PAM conversation fix
 
 ---
  auth-pam.c | 36 ++++++++++++++++++++++++++++++++++++
@@ -94,5 +94,5 @@ index 0b4a28ab..253c37d0 100644
  		debug("PAM: password authentication accepted for %.100s",
  		    authctxt->user);
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0010-PAM-enhancements-for-Solaris.patch
+++ b/openssh/Patches/0010-PAM-enhancements-for-Solaris.patch
@@ -1,7 +1,7 @@
-From 9fdf6bfce612c0c22f1e7fe06b5e916a28343195 Mon Sep 17 00:00:00 2001
+From 342c2e972f73e7d75563113a74a32626efce162f Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:36:19 -0700
-Subject: [PATCH 10/34] PAM enhancements for Solaris
+Subject: [PATCH 10/35] PAM enhancements for Solaris
 
 ---
  auth-pam.c     | 116 ++++++++++++++++++++++++++++++++++++++++++++++++-
@@ -660,5 +660,5 @@ index ffbb527f..dca926d0 100644
  Optionally specifies additional text to append to the SSH protocol banner
  sent by the server upon connection.
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0011-SunSSH-compat-default-config-values.patch
+++ b/openssh/Patches/0011-SunSSH-compat-default-config-values.patch
@@ -1,7 +1,7 @@
-From 9833f97f4ba06b30e9db47605a5b63eeab24f367 Mon Sep 17 00:00:00 2001
+From 671b7b054e6c24f1f27a965e3bb8761b8a79cb09 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:36:22 -0700
-Subject: [PATCH 11/34] SunSSH compat default config values
+Subject: [PATCH 11/35] SunSSH compat default config values
 
 Some options in OpenSSH have different default values from those in SunSSH.
 To make the transition smoother from SunSSH to OpenSSH, we change default
@@ -128,5 +128,5 @@ index dca926d0..b0a7772e 100644
  When X11 forwarding is enabled, there may be additional exposure to
  the server and to client displays if the
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0012-Deprecate-SunSSH-compatible-server-options.patch
+++ b/openssh/Patches/0012-Deprecate-SunSSH-compatible-server-options.patch
@@ -1,7 +1,7 @@
-From 9a8db267a1e9ee1aa6757ec65ae051f93772c2ba Mon Sep 17 00:00:00 2001
+From 7cde9fe0b10e7b2e805e107bcfa908f5145700c9 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:36:33 -0700
-Subject: [PATCH 12/34] Deprecate SunSSH compatible server options
+Subject: [PATCH 12/35] Deprecate SunSSH compatible server options
 
 #
 # Originally we planned to only deprecate client config (ssh_config) options
@@ -57,5 +57,5 @@ index af0d6e0c..09847be6 100644
  	{ "revokedkeys", sRevokedKeys, SSHCFG_ALL },
  	{ "trustedusercakeys", sTrustedUserCAKeys, SSHCFG_ALL },
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0013-Don-t-blow-up-on-deprecated-GSS-key-exchange-options.patch
+++ b/openssh/Patches/0013-Don-t-blow-up-on-deprecated-GSS-key-exchange-options.patch
@@ -1,7 +1,7 @@
-From c5385cbaeca9dcf4f7d0745b44905d8d78a4d47d Mon Sep 17 00:00:00 2001
+From d7af9ec1e7f46b954a4a0f1c38e7630e87f76103 Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex@uq.edu.au>
 Date: Tue, 8 Jun 2021 15:37:04 +1000
-Subject: [PATCH 13/34] Don't blow up on deprecated GSS key exchange options
+Subject: [PATCH 13/35] Don't blow up on deprecated GSS key exchange options
 
 ---
  servconf.c | 6 ++++++
@@ -25,5 +25,5 @@ index 09847be6..9da37110 100644
  	{ "revokedkeys", sRevokedKeys, SSHCFG_ALL },
  	{ "trustedusercakeys", sTrustedUserCAKeys, SSHCFG_ALL },
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0014-Solaris-Auditing-support.patch
+++ b/openssh/Patches/0014-Solaris-Auditing-support.patch
@@ -1,7 +1,7 @@
-From 07ab1ee7313fe9b0df1e7bc940bf41d75acb9158 Mon Sep 17 00:00:00 2001
+From d88f717d7b09b5a4ed59e1ab41adba503445d326 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:37:01 -0700
-Subject: [PATCH 14/34] Solaris Auditing support
+Subject: [PATCH 14/35] Solaris Auditing support
 
 ---
  INSTALL         |  15 +-
@@ -800,5 +800,5 @@ index 12879c49..dded9190 100644
  	/*
  	 * In privilege separation, we fork another child and prepare
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0015-Enable-login-to-a-role-if-PAM-is-ok-with-it.patch
+++ b/openssh/Patches/0015-Enable-login-to-a-role-if-PAM-is-ok-with-it.patch
@@ -1,7 +1,7 @@
-From 38e26e897d40a6fd8df26b7c69bc2b1671dfb8e0 Mon Sep 17 00:00:00 2001
+From 1188577cea5802f75905732216e5f225c156f441 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:38:19 -0700
-Subject: [PATCH 15/34] Enable login to a role if PAM is ok with it
+Subject: [PATCH 15/35] Enable login to a role if PAM is ok with it
 
 ---
  auth-pam.c        | 14 ++++++++++++++
@@ -154,5 +154,5 @@ index dd596e80..f936efd1 100644
  
  	if ((r = sshbuf_put_u32(m, ret)) != 0 ||
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0016-PAM-setcred-failures.patch
+++ b/openssh/Patches/0016-PAM-setcred-failures.patch
@@ -1,7 +1,7 @@
-From 7eee460690bdeee20cf792e369c91297df28945f Mon Sep 17 00:00:00 2001
+From b1661f49f10117a3ed39cdff3146f3118742eea5 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:38:26 -0700
-Subject: [PATCH 16/34] PAM setcred failures
+Subject: [PATCH 16/35] PAM setcred failures
 
 #
 # This patch contains bug fixes to the PAM credential and session operations.
@@ -61,5 +61,5 @@ index c8018aa4..56c71746 100644
  
  }
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0017-Don-t-call-do_pam_setcred-twice.patch
+++ b/openssh/Patches/0017-Don-t-call-do_pam_setcred-twice.patch
@@ -1,7 +1,7 @@
-From 3ec78526ba80f5126240a3fbb1b029780218b976 Mon Sep 17 00:00:00 2001
+From d386381a3d0e52fa8fa308d38b974801ad45b81e Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:38:41 -0700
-Subject: [PATCH 17/34] Don't call do_pam_setcred twice
+Subject: [PATCH 17/35] Don't call do_pam_setcred twice
 
 # This issue has been raised with the upstream OpenSSH community:
 #
@@ -43,5 +43,5 @@ index 44ba71dc..0b4f1a78 100644
  	 * PAM credentials may take the form of supplementary groups.
  	 * These will have been wiped by the above initgroups() call.
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0018-Per-session-xauthfile.patch
+++ b/openssh/Patches/0018-Per-session-xauthfile.patch
@@ -1,7 +1,7 @@
-From 0541b8b2102128dc08f0d7c64157fbc3b662a336 Mon Sep 17 00:00:00 2001
+From 74063a7c03d25a3ec29d7be9669ecc68a8402405 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Tue, 22 Dec 2015 17:12:50 -0800
-Subject: [PATCH 18/34] Per-session xauthfile
+Subject: [PATCH 18/35] Per-session xauthfile
 
 This patch is to fix a X11 connection failure when a user's home directory
 is read-only.
@@ -238,5 +238,5 @@ index ce59dabd..1f078799 100644
  
  	int	chanid;
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0019-PubKeyPlugin-support.patch
+++ b/openssh/Patches/0019-PubKeyPlugin-support.patch
@@ -1,7 +1,7 @@
-From 2277df9ecfeb8102085e73f534fb0d90b7a6b901 Mon Sep 17 00:00:00 2001
+From bec0f3fea15a38f5fd754de49c0b562afb922edb Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Mon, 3 Aug 2015 16:27:44 -0700
-Subject: [PATCH 19/34] PubKeyPlugin support
+Subject: [PATCH 19/35] PubKeyPlugin support
 
 This adds the PubKeyPlugin directive and associated code from
 SunSSH, allowing an in-process shared library to be called
@@ -269,5 +269,5 @@ index c65acda3..a3159c1f 100644
  
  /* Information about the incoming connection as used by Match */
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0020-Compatibility-fix-for-ListenAddress.patch
+++ b/openssh/Patches/0020-Compatibility-fix-for-ListenAddress.patch
@@ -1,7 +1,7 @@
-From 02c938ee80b41af1f69338699adf706ea258aa48 Mon Sep 17 00:00:00 2001
+From 794a0d06e2a59e617dc3351918c96cd244a8b7db Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Mon, 3 Aug 2015 17:27:41 -0700
-Subject: [PATCH 20/34] Compatibility fix for "ListenAddress ::"
+Subject: [PATCH 20/35] Compatibility fix for "ListenAddress ::"
 
 In SunSSH, a config that specifies only "ListenAddress ::" in
 fact will listen on both IPv4 and IPv6.
@@ -37,5 +37,5 @@ index 36a73e49..8644abf3 100644
  	options->queued_listen_addrs = NULL;
  	options->num_queued_listens = 0;
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0021-Try-to-create-privsep-chroot-dir-if-it-doesn-t-exist.patch
+++ b/openssh/Patches/0021-Try-to-create-privsep-chroot-dir-if-it-doesn-t-exist.patch
@@ -1,7 +1,7 @@
-From 47aec3c4be0ee1c79aed6d0d471d4e86488025c5 Mon Sep 17 00:00:00 2001
+From c9ff7eb57fc0a129032a0d8a57bd484d54afa10f Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Wed, 5 Aug 2015 12:25:15 -0700
-Subject: [PATCH 21/34] Try to create privsep chroot dir if it doesn't exist
+Subject: [PATCH 21/35] Try to create privsep chroot dir if it doesn't exist
  yet
 
 ---
@@ -47,5 +47,5 @@ index dded9190..6238f6ab 100644
  #ifdef HAVE_CYGWIN
  		if (check_ntsec(_PATH_PRIVSEP_CHROOT_DIR) &&
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0022-Add-SMF-manifest-and-method-and-install-them.patch
+++ b/openssh/Patches/0022-Add-SMF-manifest-and-method-and-install-them.patch
@@ -1,7 +1,7 @@
-From bd7d396480b4c9da251f428ae2734cea122059df Mon Sep 17 00:00:00 2001
+From 2fbd302508fdbfbe98728d9c2a097b0ea4194c5b Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Fri, 7 Aug 2015 12:19:47 -0700
-Subject: [PATCH 22/34] Add SMF manifest and method, and install them
+Subject: [PATCH 22/35] Add SMF manifest and method, and install them
 
 ---
  Makefile.in      |   6 ++
@@ -350,5 +350,5 @@ index 00000000..bd43e7da
 +
 +exit $?
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0023-Make-default-sshd_config-more-like-the-old-illumos-o.patch
+++ b/openssh/Patches/0023-Make-default-sshd_config-more-like-the-old-illumos-o.patch
@@ -1,7 +1,7 @@
-From e9c2bdcbe69ed3fec44a324c3b2795f3a3436bd5 Mon Sep 17 00:00:00 2001
+From 7c3365435f8044c26c16a898fbe758f2eae760a7 Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Fri, 7 Aug 2015 13:24:58 -0700
-Subject: [PATCH 23/34] Make default sshd_config more like the old illumos one
+Subject: [PATCH 23/35] Make default sshd_config more like the old illumos one
 
 ---
  sshd_config | 44 +++++++++++++++++++++++---------------------
@@ -93,5 +93,5 @@ index 19b7c91a..657c4415 100644
  #PermitUserEnvironment no
  #Compression delayed
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0024-Add-with-key-dir-configure-option-to-place-SSH-host-.patch
+++ b/openssh/Patches/0024-Add-with-key-dir-configure-option-to-place-SSH-host-.patch
@@ -1,7 +1,7 @@
-From c447ad62099f7ce7c22adc77f500975dfaccf486 Mon Sep 17 00:00:00 2001
+From ff0baea72cb5b8d808d40c68aa202fd33342d34c Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Fri, 7 Aug 2015 13:32:53 -0700
-Subject: [PATCH 24/34] Add --with-key-dir configure option to place SSH host
+Subject: [PATCH 24/35] Add --with-key-dir configure option to place SSH host
  keys
 
 ---
@@ -126,5 +126,5 @@ index f7ca5a75..48d9e68b 100644
  #ifndef _PATH_SSH_PROGRAM
  #define _PATH_SSH_PROGRAM		"/usr/bin/ssh"
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0025-Don-t-use-krb5-config-to-check-for-GSSAPI-on-Illumos.patch
+++ b/openssh/Patches/0025-Don-t-use-krb5-config-to-check-for-GSSAPI-on-Illumos.patch
@@ -1,7 +1,7 @@
-From 69b32392a46f15cc3ba02cfa1f8766953adbec9c Mon Sep 17 00:00:00 2001
+From 81a192fae2963bcd7297a0959bb64803a041ac77 Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Fri, 21 Aug 2015 18:47:46 -0700
-Subject: [PATCH 25/34] Don't use krb5-config to check for GSSAPI on Illumos
+Subject: [PATCH 25/35] Don't use krb5-config to check for GSSAPI on Illumos
 
 ---
  configure.ac | 7 ++++++-
@@ -33,5 +33,5 @@ index 430b3f62..d74859f9 100644
  			AC_SEARCH_LIBS([dn_expand], [resolv])
  
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0026-Set-default-sshd-options-based-on-etc-default-login.patch
+++ b/openssh/Patches/0026-Set-default-sshd-options-based-on-etc-default-login.patch
@@ -1,7 +1,7 @@
-From 0431e1cb8c018e9daacc04985660a400cf392cf8 Mon Sep 17 00:00:00 2001
+From 91378652553c9e51885b83680b3940f69d7ed484 Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Mon, 24 Aug 2015 18:57:27 -0700
-Subject: [PATCH 26/34] Set default sshd options based on /etc/default/login
+Subject: [PATCH 26/35] Set default sshd options based on /etc/default/login
 
 ---
  pathnames.h   |  1 +
@@ -141,5 +141,5 @@ index b0a7772e..e3969af1 100644
  Specifies the addresses/ports on which a remote TCP port forwarding may listen.
  The listen specification must be one of the following forms:
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0027-Compatibility-for-SunSSH_1.5-should-include-old-DH-K.patch
+++ b/openssh/Patches/0027-Compatibility-for-SunSSH_1.5-should-include-old-DH-K.patch
@@ -1,7 +1,7 @@
-From b2d86ac94c9fd4af455a5347b2e498c0ac180775 Mon Sep 17 00:00:00 2001
+From 26fb811bbf8122820b0d9b1858aaf8d2c8180386 Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Fri, 4 Sep 2015 10:38:28 -0700
-Subject: [PATCH 27/34] Compatibility for SunSSH_1.5* should include old DH KEx
+Subject: [PATCH 27/35] Compatibility for SunSSH_1.5* should include old DH KEx
  algos
 
 We use the kex compat mechanism here to recognise old SunSSH
@@ -134,5 +134,5 @@ index 69befa96..6fe8cce5 100644
  	debug2_f("compat KEX proposal: %s", p);
  	if (*p == '\0')
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0028-Accept-and-send-LANG-and-LC_-environment-variables-b.patch
+++ b/openssh/Patches/0028-Accept-and-send-LANG-and-LC_-environment-variables-b.patch
@@ -1,7 +1,7 @@
-From 94f35e5fc9cfb7cbf396f69583627864d87c20ae Mon Sep 17 00:00:00 2001
+From d85a0c74d5acd68ac211b79db6243501352856dc Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Fri, 4 Sep 2015 11:04:30 -0700
-Subject: [PATCH 28/34] Accept and send LANG and LC_* environment variables by
+Subject: [PATCH 28/35] Accept and send LANG and LC_* environment variables by
  default
 
 This preserves most of the old SunSSH locale negotiation
@@ -264,5 +264,5 @@ index e3969af1..bc08fbef 100644
  Specifies which address family should be used by
  .Xr sshd 1M .
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0029-Temporarily-set-ssh-keygen-and-ssh-add-to-old-FP-for.patch
+++ b/openssh/Patches/0029-Temporarily-set-ssh-keygen-and-ssh-add-to-old-FP-for.patch
@@ -1,7 +1,7 @@
-From 5e127892d236acf2f1b7cfca7175a811fb13f905 Mon Sep 17 00:00:00 2001
+From f53f2d549cca5d279c5352b2dad61f7789fadb65 Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Wed, 9 Sep 2015 10:36:05 -0700
-Subject: [PATCH 29/34] Temporarily set ssh-keygen and ssh-add to old FP format
+Subject: [PATCH 29/35] Temporarily set ssh-keygen and ssh-add to old FP format
 
 SDC and its users have a lot of scripts that expect ssh-add
 and ssh-keygen to return fingerprints in the old format.
@@ -143,5 +143,5 @@ index 027c6db6..61d907a1 100644
  				fatal("Invalid hash algorithm \"%s\"", optarg);
  			break;
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0030-Restore-tcpwrappers-libwrap-support.patch
+++ b/openssh/Patches/0030-Restore-tcpwrappers-libwrap-support.patch
@@ -1,7 +1,7 @@
-From 5668e6cccc468442cd33c1cfb851da6010a5a231 Mon Sep 17 00:00:00 2001
+From 91753f709421a1f3a0dce2e8370af426f9a2d700 Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Wed, 16 Sep 2015 10:54:13 -0700
-Subject: [PATCH 30/34] Restore tcpwrappers/libwrap support
+Subject: [PATCH 30/35] Restore tcpwrappers/libwrap support
 
 This reverts commit f9696566fb41320820f3b257ab564fa321bb3751
 and commit f2719b7c2b8a3b14d778d8a6d8dc729b5174b054.
@@ -159,5 +159,5 @@ index ca3acf77..824ea16a 100644
  	rdomain = ssh_packet_rdomain_in(ssh);
  
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0031-Let-us-put-a-fallback-copy-of-DH-moduli-in-a-system-.patch
+++ b/openssh/Patches/0031-Let-us-put-a-fallback-copy-of-DH-moduli-in-a-system-.patch
@@ -1,7 +1,7 @@
-From 9a13359c234eea6422541f2616c2edcb4d5b39ee Mon Sep 17 00:00:00 2001
+From 21edf0aaeecaeec2fae652c4106e3dd2cd1a00f8 Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Thu, 15 Oct 2015 16:02:37 -0700
-Subject: [PATCH 31/34] Let us put a fallback copy of DH moduli in a system
+Subject: [PATCH 31/35] Let us put a fallback copy of DH moduli in a system
  path
 
 Live distributions like SmartOS can't keep and update default
@@ -123,5 +123,5 @@ index ce2eb472..0b157d64 100644
  
  static int
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0032-Temporarily-set-ssh-keygen-to-use-old-PKCS-1-PEM-for.patch
+++ b/openssh/Patches/0032-Temporarily-set-ssh-keygen-to-use-old-PKCS-1-PEM-for.patch
@@ -1,7 +1,7 @@
-From da99b415abd0bf191d3caee4b3b9d26cd887359d Mon Sep 17 00:00:00 2001
+From 69beb98228ff5db751049b967e90ccb6f139ab1c Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Tue, 16 Jul 2019 13:43:14 -0700
-Subject: [PATCH 32/34] Temporarily set ssh-keygen to use old PKCS#1 PEM format
+Subject: [PATCH 32/35] Temporarily set ssh-keygen to use old PKCS#1 PEM format
 
 SDC and its users have a lot of scripts and tools which expect
 ssh-keygen to produce the old private key format.
@@ -140,5 +140,5 @@ index 61d907a1..dc1261af 100644
  	if ((r = sshkey_save_private(private, identity_file, passphrase,
  	    comment, private_key_format, openssh_format_cipher, rounds)) != 0) {
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/0033-CVE-2021-41617.patch
+++ b/openssh/Patches/0033-CVE-2021-41617.patch
@@ -1,16 +1,21 @@
-From f3cbe43e28fe71427d41cfe3a17125b972710455 Mon Sep 17 00:00:00 2001
+From 8a45a79bc07ced70e9ce35edaaed8d87b776b24f Mon Sep 17 00:00:00 2001
 From: "djm@openbsd.org" <djm@openbsd.org>
 Date: Sun, 26 Sep 2021 14:01:03 +0000
-Subject: [PATCH] upstream: need initgroups() before setresgid(); reported by
- anton@,
+Subject: [PATCH 33/35] upstream: need initgroups() before setresgid();
+ reported by anton@,
 
 ok deraadt@
 
 OpenBSD-Commit-ID: 6aa003ee658b316960d94078f2a16edbc25087ce
-diff -wpruN '--exclude=*.orig' a~/misc.c a/misc.c
---- a~/misc.c	1970-01-01 00:00:00
-+++ a/misc.c	1970-01-01 00:00:00
-@@ -2629,6 +2629,12 @@ subprocess(const char *tag, const char *
+---
+ misc.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/misc.c b/misc.c
+index b0ece244..2fe9aa9f 100644
+--- a/misc.c
++++ b/misc.c
+@@ -2626,6 +2626,12 @@ subprocess(const char *tag, const char *command,
  		}
  		closefrom(STDERR_FILENO + 1);
  
@@ -23,3 +28,6 @@ diff -wpruN '--exclude=*.orig' a~/misc.c a/misc.c
  		if (setresgid(pw->pw_gid, pw->pw_gid, pw->pw_gid) == -1) {
  			error("%s: setresgid %u: %s", tag, (u_int)pw->pw_gid,
  			    strerror(errno));
+-- 
+2.34.1
+

--- a/openssh/Patches/1000-smartos-dtrace32.patch
+++ b/openssh/Patches/1000-smartos-dtrace32.patch
@@ -1,7 +1,7 @@
-From ad54bbee75237a820bfae6790d1a9abe0db0e46e Mon Sep 17 00:00:00 2001
+From 0e3c769f70a4317bbb062993b42b46c9022fbe43 Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Tue, 22 Dec 2015 14:30:19 -0800
-Subject: [PATCH 33/34] SmartOS local: make dtrace lib 32-bit
+Subject: [PATCH 34/35] SmartOS local: make dtrace lib 32-bit
 
 ---
  Makefile.in | 5 +++--
@@ -38,5 +38,5 @@ index c1d2d848..80adc98f 100644
  	$(srcdir)/mkinstalldirs $(SMFNETMANIDIR)
  	$(INSTALL) -m 555 smf/method.sh $(SMFMETHODDIR)/sshd
 -- 
-2.31.1
+2.34.1
 

--- a/openssh/Patches/1001-sunw_ssl.patch
+++ b/openssh/Patches/1001-sunw_ssl.patch
@@ -1,7 +1,7 @@
-From b4773dd7d392bed0fffc228cdf461fc995e37745 Mon Sep 17 00:00:00 2001
+From c359868d3109dd09fea942e6616a7b793f49fc76 Mon Sep 17 00:00:00 2001
 From: Alex Wilson <alex.wilson@joyent.com>
 Date: Tue, 22 Dec 2015 14:31:25 -0800
-Subject: [PATCH 34/34] SmartOS local: use sunw_ssl lib from platform
+Subject: [PATCH 35/35] SmartOS local: use sunw_ssl lib from platform
 
 ---
  cipher-chachapoly-libcrypto.c        |   4 +-
@@ -866,5 +866,5 @@ index 8ca50b5a..0dfb1c15 100644
  #endif /* WITH_OPENSSL */
  #endif /* _OPENSSL_COMPAT_H */
 -- 
-2.31.1
+2.34.1
 


### PR DESCRIPTION
thanks to Rob Seastrom and Sean Weatherall for reporting this on the smartos mailinglist

testing done:
 * built new PI with this change, booted it
 * ssh'd into gz, still works
 * did `ssh user@host` to a host without a banner configured, verified it works
 * did `ssh user@host` to a host with a banner, no more segfault
 * did `ssh user@host 'echo hi'` to the same host, no banner in the output (just 'hi')